### PR TITLE
Updated base version in cabal

### DIFF
--- a/hobbes.cabal
+++ b/hobbes.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.8
 executable hobbes
   main-is:             Hobbes.hs
   -- other-modules:       
-  build-depends:       base ==4.5.*, 
+  build-depends:       base >= 4 && < 5, 
                        filepath ==1.3.*, 
                        filemanip ==0.3.*, 
                        hfsevents ==0.1.*


### PR DESCRIPTION
You should be fine to have any version of base 4.
