### PR TITLE
Changes to use of handles

### DIFF
--- a/Hobbes.hs
+++ b/Hobbes.hs
@@ -10,6 +10,7 @@ import System.OSX.FSEvents
 
 import Control.Monad (forever, when)
 import Control.Exception (bracket)
+import Control.Concurrent (yield)
 
 import Data.Bits ((.&.))
 
@@ -32,8 +33,8 @@ runWatcher path =
   let (dir, glob) = splitFileName path
   in bracket
        (eventStreamCreate [dir] 1.0 True True True (handleEvent glob))
-       (\es -> eventStreamDestroy es >> putStrLn "Bye Bye!")
-       (const $ forever getLine)
+       (\es -> eventStreamDestroy es >> hPutStrLn stderr "Bye Bye!")
+       (const $ forever yield)
 
 handleEvent :: GlobPattern -> Event -> IO ()
 handleEvent glob evt = 


### PR DESCRIPTION
Skip reading from STDIN (which might might be closed) and print "Bye Bye" to
stderr (to prevent it from being mingled with the output stream).
