### PR TITLE
Add source repository for cabal.

### DIFF
--- a/hobbes.cabal
+++ b/hobbes.cabal
@@ -12,6 +12,10 @@ category:            System
 build-type:          Simple
 cabal-version:       >=1.8
 
+source-repository head
+  type:     git
+  location: https://github.com/jhickner/hobbes.git
+
 executable hobbes
   main-is:             Hobbes.hs
   -- other-modules:       


### PR DESCRIPTION
∴ cabal get -s hobbes
cabal: Package hobbes-0.2.1 does not have any source repositories.
