### PR TITLE
New option parsing, support of multiple paths

### DIFF
--- a/hobbes.cabal
+++ b/hobbes.cabal
@@ -19,4 +19,5 @@ executable hobbes
                        filepath ==1.4.*,
                        filemanip ==0.3.*,
                        fsnotify >= 0.0.11,
-                       text >= 1.1.0.1
+                       text >= 1.1.0.1,
+                       optparse-applicative >= 0.12

--- a/hobbes.cabal
+++ b/hobbes.cabal
@@ -1,5 +1,5 @@
 name:                hobbes
-version:             0.2.2
+version:             0.3.0
 synopsis:            A small file watcher for OSX
 -- description:
 homepage:            http://github.com/jhickner/hobbes

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,6 @@ flags: {}
 packages:
     - '.'
 extra-deps: []
-resolver: lts-3.2
+resolver: lts-5.13
 ghc-options:
-    "*": -static -optl-static -optl-pthread
+    hobbes: -static -optl-static -optl-pthread


### PR DESCRIPTION
This PR
- rewrites an option parsing with `optparse-applicative` (now parsing is more "typed" and has a fancy `-h/--help`)
- makes possible to use more than one `PATH` in cmdline
